### PR TITLE
Add log encryption

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,4 @@ dmypy.json
 .vscode/
 **/.DS_Store
 start.sh
-bot_subscribers/*
+json/*

--- a/chatbot.py
+++ b/chatbot.py
@@ -92,12 +92,12 @@ class Chatbot:
             account_sid: str,
             auth_token: str,
             number: str,
-            json_file: str = "bot_subscribers/subscribers.json",
-            backup_file: str = "bot_subscribers/backup.json",
-            key_file: str = "json/key.key",
-            logs_file: str = "json/logs.json",
-            backup_logs_file: str = "json/backup_logs.json",
-            logs_key_file: str = "json/key2.key"):
+            json_file: str = "subscribers.json",
+            backup_file: str = "subscribers_bak.json",
+            key_file: str = "subscribers_key.key",
+            logs_file: str = "logs.json",
+            backup_logs_file: str = "logs_bak.json",
+            logs_key_file: str = "logs_key.key"):
         """Create the ChatBot object and populate class members as needed.
 
         Arguments:
@@ -114,16 +114,18 @@ class Chatbot:
                 above JSON file
             logs_key_file -- Path to a file containing the encryption key
         """
+        # TODO: above needs to be changed to the doc style currently in the 260
+        # branch (note key word args)
         if Chatbot.languages is None:
             Chatbot.languages = LangData()
         self.client = Client(account_sid, auth_token)
         self.number = number
-        self.json_file = json_file
-        self.backup_file = backup_file
-        self.key_file = key_file
-        self.logs_file = logs_file
-        self.backup_logs_file = backup_logs_file
-        self.logs_key_file = logs_key_file
+        self.json_file = f"json/{json_file}"
+        self.backup_file = f"json/{backup_file}"
+        self.key_file = f"json/{key_file}"
+        self.logs_file = f"json/{logs_file}"
+        self.backup_logs_file = f"json/{backup_logs_file}"
+        self.logs_key_file = f"json/{logs_key_file}"
         self.twilio_account_sid = account_sid
         self.twilio_auth_token = auth_token
         self.twilio_number = number
@@ -143,8 +145,7 @@ class Chatbot:
                 backup_encrypted_data = file.read()
             backup_unencrypted_data = f.decrypt(
                 backup_encrypted_data).decode("utf-8")
-            self.subscribers: Dict[str, SubscribersInfo] = json.loads(
-                backup_unencrypted_data)
+            self.subscribers = json.loads(backup_unencrypted_data)
         self.display_names: Dict[str, str] = {
             v["name"]: k for k, v in self.subscribers.items()}
 
@@ -513,25 +514,14 @@ class Chatbot:
                     return self._push(text, sender_contact, media_urls)
 
 
+# Create bot (keyword args not provided because they have defaults)
 TWILIO_ACCOUNT_SID: str = os.getenv(
     "TWILIO_ACCOUNT_SID")  # type: ignore [assignment]
 TWILIO_AUTH_TOKEN: str = os.getenv(
     "TWILIO_AUTH_TOKEN")  # type: ignore [assignment]
 TWILIO_NUMBER: str = os.getenv("TWILIO_NUMBER")  # type: ignore [assignment]
-SUBSCRIBER_FILE: str = "bot_subscribers/subscribers.json"
-BACKUP_FILE: str = "bot_subscribers/backup.json"
-KEY_FILE: str = "json/key.key"
-LOGS_FILE: str = "json/logs.json"
-BACKUP_LOGS_FILE: str = "json/backup_logs.json"
-LOGS_KEY_FILE: str = "json/key2.key"
 mr_botty = Chatbot(
     TWILIO_ACCOUNT_SID,
     TWILIO_AUTH_TOKEN,
-    TWILIO_NUMBER,
-    SUBSCRIBER_FILE,
-    BACKUP_FILE,
-    KEY_FILE,
-    LOGS_FILE,
-    BACKUP_LOGS_FILE,
-    LOGS_KEY_FILE)
+    TWILIO_NUMBER)
 """Global Chatbot object, of which there could theoretically be many."""

--- a/json/key.key
+++ b/json/key.key
@@ -1,1 +1,0 @@
-CKrNCf_Rc04QvzdDNnntCLoxzfE1YS2GDol0m9idrq0=

--- a/json/key2.key
+++ b/json/key2.key
@@ -1,0 +1,1 @@
+Gs0bX9ZbwJd9COZ7I9M3_ZnfXKgY_rD_hdOfSgcvYRc=

--- a/json/key2.key
+++ b/json/key2.key
@@ -1,1 +1,0 @@
-Gs0bX9ZbwJd9COZ7I9M3_ZnfXKgY_rD_hdOfSgcvYRc=

--- a/setup.py
+++ b/setup.py
@@ -17,8 +17,10 @@ BOLD = "\033[;1m"
 RESET = "\033[0;0m"
 
 # File name
-JSON_FILE = "team56test.json"
+JSON_FILE = "subscribers.json"
 BACKUP_FILE = "backup.json"
+LOGS_FILE = "logs.json"
+BACKUP_LOGS_FILE = "backup_logs.json"
 
 
 def usage():
@@ -75,7 +77,7 @@ display_name = input().replace(" ", "")  # remove spaces
 user_dict = dict({f"whatsapp:{phone_number}": {
                  "lang": language, "name": display_name, "role": "super"}})
 
-# Create a key or Retrieve a key if file already exists
+# Create a key or Retrieve a key if file already exists for user data
 if not os.path.isfile("json/key.key"):
     key = Fernet.generate_key()
     with open("json/key.key", "xb") as file:
@@ -115,6 +117,51 @@ except FileExistsError:
     sys.stdout.write(BOLD + RED)
     print(
         f"\nA file under bot_subscribers/{BACKUP_FILE} already exists. " +
+        "Delete and try again.")
+    sys.stdout.write(RESET)
+    sys.exit(1)
+
+# Create a key or Retrieve a key if file already exists for logs data
+if not os.path.isfile("json/key2.key"):
+    key2 = Fernet.generate_key()
+    with open("json/key2.key", "xb") as file:
+        file.write(key2)
+else:
+    with open("json/key2.key", "rb") as file:
+        key2 = file.read()
+
+# Create logs file
+logs_dict = dict({f"whatsapp:{phone_number}": {"timestamps": []}})
+logs_list = json.dumps(logs_dict, indent=4)
+# Create byte version of JSON string
+logs_list_byte = logs_list.encode("utf-8")
+f = Fernet(key2)
+logs_encrypted_data = f.encrypt(logs_list_byte)
+
+try:
+    with open(f"json/{LOGS_FILE}", "xb") as file:
+        file.write(logs_encrypted_data)
+    sys.stdout.write(BOLD + GREEN)
+    print(f"\njson/{LOGS_FILE} created.")
+    sys.stdout.write(RESET)
+except FileExistsError:
+    sys.stdout.write(BOLD + RED)
+    print(
+        f"\nA file under json/{LOGS_FILE} already exists. " +
+        "Delete and try again.")
+    sys.stdout.write(RESET)
+    sys.exit(1)
+
+try:
+    with open(f"json/{BACKUP_LOGS_FILE}", "xb") as file:
+        file.write(logs_encrypted_data)
+    sys.stdout.write(BOLD + GREEN)
+    print(f"\njson/{BACKUP_LOGS_FILE} created.")
+    sys.stdout.write(RESET)
+except FileExistsError:
+    sys.stdout.write(BOLD + RED)
+    print(
+        f"\nA file under json/{BACKUP_LOGS_FILE} already exists. " +
         "Delete and try again.")
     sys.stdout.write(RESET)
     sys.exit(1)

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ data to be used for all of the included Chatbot functionality.
 import json
 import os
 import sys
+from typing import Dict, List
 
 from cryptography.fernet import Fernet  # type: ignore [import]
 
@@ -16,20 +17,14 @@ GREEN = "\033[1;32m"
 BOLD = "\033[;1m"
 RESET = "\033[0;0m"
 
-# File name
+# File names
+JSON_DIR = "json"
 JSON_FILE = "subscribers.json"
-BACKUP_FILE = "backup.json"
+BACKUP_FILE = "subscribers_bak.json"
+KEY_FILE = "subscribers_key.key"
 LOGS_FILE = "logs.json"
-BACKUP_LOGS_FILE = "backup_logs.json"
-
-
-def usage():
-    """Print a usage statement."""
-    print("USAGE:")
-    sys.stdout.write(BOLD)
-    print(f"    {sys.argv[0]}", end="")
-    sys.stdout.write(RESET)
-    print(" [JSON file name]")
+BACKUP_LOGS_FILE = "logs_bak.json"
+LOGS_KEY_FILE = "logs_key.key"
 
 
 print("Setting up user data file...\n")
@@ -77,13 +72,17 @@ display_name = input().replace(" ", "")  # remove spaces
 user_dict = dict({f"whatsapp:{phone_number}": {
                  "lang": language, "name": display_name, "role": "super"}})
 
-# Create a key or Retrieve a key if file already exists for user data
-if not os.path.isfile("json/key.key"):
+# Look for json directory and create if needed
+if not os.path.exists(f"{JSON_DIR}/"):
+    os.makedirs(f"{JSON_DIR}/")
+
+# Create a key or retrieve a key if file already exists for user data
+if not os.path.isfile(f"{JSON_DIR}/{KEY_FILE}"):
     key = Fernet.generate_key()
-    with open("json/key.key", "xb") as file:
+    with open(f"{JSON_DIR}/{KEY_FILE}", "xb") as file:
         file.write(key)
 else:
-    with open("json/key.key", "rb") as file:
+    with open(f"{JSON_DIR}/{KEY_FILE}", "rb") as file:
         key = file.read()
 
 # Create super administrator
@@ -94,44 +93,46 @@ f = Fernet(key)
 encrypted_data = f.encrypt(user_list_byte)
 
 try:
-    with open(f"bot_subscribers/{JSON_FILE}", "xb") as file:
+    with open(f"{JSON_DIR}/{JSON_FILE}", "xb") as file:
         file.write(encrypted_data)
     sys.stdout.write(BOLD + GREEN)
-    print(f"\nbot_subscribers/{JSON_FILE} created.")
+    print(f"{JSON_DIR}/{JSON_FILE} created.")
     sys.stdout.write(RESET)
 except FileExistsError:
     sys.stdout.write(BOLD + RED)
     print(
-        f"\nA file under bot_subscribers/{JSON_FILE} already exists. " +
-        "Delete and try again.")
+        f"\nA file under {JSON_DIR}/{JSON_FILE} already exists. " +
+        "Delete and try again if you're certain.")
     sys.stdout.write(RESET)
     sys.exit(1)
 
 try:
-    with open(f"bot_subscribers/{BACKUP_FILE}", "xb") as file:
+    with open(f"{JSON_DIR}/{BACKUP_FILE}", "xb") as file:
         file.write(encrypted_data)
     sys.stdout.write(BOLD + GREEN)
-    print(f"\nbot_subscribers/{BACKUP_FILE} created.")
+    print(f"{JSON_DIR}/{BACKUP_FILE} created.")
     sys.stdout.write(RESET)
 except FileExistsError:
     sys.stdout.write(BOLD + RED)
     print(
         f"\nA file under bot_subscribers/{BACKUP_FILE} already exists. " +
-        "Delete and try again.")
+        "Delete and try again if you're certain.")
     sys.stdout.write(RESET)
     sys.exit(1)
 
 # Create a key or Retrieve a key if file already exists for logs data
-if not os.path.isfile("json/key2.key"):
+if not os.path.isfile(f"{JSON_DIR}/{LOGS_KEY_FILE}"):
     key2 = Fernet.generate_key()
-    with open("json/key2.key", "xb") as file:
+    with open(f"{JSON_DIR}/{LOGS_KEY_FILE}", "xb") as file:
         file.write(key2)
 else:
-    with open("json/key2.key", "rb") as file:
+    with open(f"{JSON_DIR}/{LOGS_KEY_FILE}", "rb") as file:
         key2 = file.read()
 
 # Create logs file
-logs_dict = dict({f"whatsapp:{phone_number}": {"timestamps": []}})
+# TODO: update to new format
+logs_dict: Dict[str, Dict[str, List[str]]] = dict(
+    {f"whatsapp:{phone_number}": {"timestamps": []}})
 logs_list = json.dumps(logs_dict, indent=4)
 # Create byte version of JSON string
 logs_list_byte = logs_list.encode("utf-8")
@@ -139,29 +140,29 @@ f = Fernet(key2)
 logs_encrypted_data = f.encrypt(logs_list_byte)
 
 try:
-    with open(f"json/{LOGS_FILE}", "xb") as file:
+    with open(f"{JSON_DIR}/{LOGS_FILE}", "xb") as file:
         file.write(logs_encrypted_data)
     sys.stdout.write(BOLD + GREEN)
-    print(f"\njson/{LOGS_FILE} created.")
+    print(f"{JSON_DIR}/{LOGS_FILE} created.")
     sys.stdout.write(RESET)
 except FileExistsError:
     sys.stdout.write(BOLD + RED)
     print(
-        f"\nA file under json/{LOGS_FILE} already exists. " +
+        f"\nA file under {JSON_DIR}/{LOGS_FILE} already exists. " +
         "Delete and try again.")
     sys.stdout.write(RESET)
     sys.exit(1)
 
 try:
-    with open(f"json/{BACKUP_LOGS_FILE}", "xb") as file:
+    with open(f"{JSON_DIR}/{BACKUP_LOGS_FILE}", "xb") as file:
         file.write(logs_encrypted_data)
     sys.stdout.write(BOLD + GREEN)
-    print(f"\njson/{BACKUP_LOGS_FILE} created.")
+    print(f"{JSON_DIR}/{BACKUP_LOGS_FILE} created.")
     sys.stdout.write(RESET)
 except FileExistsError:
     sys.stdout.write(BOLD + RED)
     print(
-        f"\nA file under json/{BACKUP_LOGS_FILE} already exists. " +
+        f"\nA file under {JSON_DIR}/{BACKUP_LOGS_FILE} already exists. " +
         "Delete and try again.")
     sys.stdout.write(RESET)
     sys.exit(1)


### PR DESCRIPTION
A couple things to take note (and wouldn't be surprised if I did one or two wrong):
1. I changed team56test.json to subscribers.json. The code should reflect this change but, again, wouldn't be surprised if I missed one.
2. There is now a second key file, logs file, and backup logs file that is generated after running setup.py. These are all in the json folder. subscribers.json and its backup remain in the bot_subscribers folder.
3. I added code to decrypt the logs file and/or backup logs file in chatbot.py. There is a #TODO marking the code for whoever actually needs to the dictionary for the logs stuff.
4. I haven't added any saving to the logs files yet, so if someone gets to that before me, just copy how we encrypted subscriber data for the logs data.